### PR TITLE
warn that the project has moved to gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # midi
 Modular library for reading and writing of MIDI messages with Go.
 
+
 [![Build Status Travis/Linux](https://travis-ci.org/gomidi/midi.svg?branch=master)](http://travis-ci.org/gomidi/midi) [![Build Status AppVeyor/Windows](https://ci.appveyor.com/api/projects/status/408nwdlo2b1lwdd1?svg=true)](https://ci.appveyor.com/project/metakeule/midi) [![Coverage Status](https://coveralls.io/repos/github/gomidi/midi/badge.svg?branch=master)](https://coveralls.io/github/gomidi/midi?branch=master) [![Go Report](https://goreportcard.com/badge/github.com/gomidi/midi)](https://goreportcard.com/report/github.com/gomidi/midi) [![Documentation](http://godoc.org/github.com/gomidi/midi?status.png)](http://godoc.org/github.com/gomidi/midi)
+
+## Notice - Moved
+
+Development has moved to GitLab https://gitlab.com/gomidi. It is recommended to use the code there instead, as the repos at Gitlab contains newer fixes, and some import references contained in the github repo may be broken.
 
 **This package is meant for users that have some knowledge of the MIDI standards. Beginners, and people on the run might want to look at the porcelain package https://github.com/gomidi/mid.**
 


### PR DESCRIPTION
Some references were broken for me, I want to warn others to use the version at gitlab to save the hassle.