### PR TITLE
Fix `portmididrv` not working on Linux

### DIFF
--- a/v2/drivers/portmididrv/imported/portmidi/porttime.go
+++ b/v2/drivers/portmididrv/imported/portmidi/porttime.go
@@ -15,7 +15,7 @@
 // Package portmidi provides PortMidi bindings.
 package portmidi
 
-// #cgo linux LDFLAGS: -lporttime
+// #cgo linux LDFLAGS: -lportmidi
 // #cgo windows LDFLAGS: -lporttime
 // #cgo darwin LDFLAGS: -lportmidi
 //


### PR DESCRIPTION
I tried usng `portmididrv` on Linux, and kept running into `-lporttime: Not found` issues when linking. 

I'm on Fedora 38. I checked that I had all the dependencies installed and `porttime.h` was in the include path. 

Seems like `porttime` is now a part of [portmidi](https://github.com/PortMidi/portmidi), so there is no `-lporttime` to be linked, `-lportmidi` should be used instead.

I tested this change by replacing the go dependency in my project for my fork, and I was able to use portmididrv without any issues
```
replace "gitlab.com/gomidi/midi/v2" v2.1.7 => /path/to/go/midi/v2
```